### PR TITLE
Add duo-wr stat

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,8 +7,8 @@ from pprint import pprint
 
 def main():
     print(stats.get_duo_wr(
-        Summoner(name="who what"),
-        Summoner(name="space created xd"))
+        Summoner(name="eat big chip"),
+        Summoner(name="arrowtothecrotch"))
     )
 
 

--- a/main.py
+++ b/main.py
@@ -6,7 +6,10 @@ from pprint import pprint
 
 
 def main():
-    print(stats.get_botlane_stats(Summoner(name="who what")))
+    print(stats.get_duo_wr(
+        Summoner(name="who what"),
+        Summoner(name="space created xd"))
+    )
 
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -6,11 +6,11 @@ from pprint import pprint
 
 
 def main():
-    print(stats.get_duo_wr(
-        Summoner(name="eat big chip"),
-        Summoner(name="arrowtothecrotch"))
-    )
-
+    # print(stats.get_duo_wr(
+    #     Summoner(name="eat big chip"),
+    #     Summoner(name="arrowtothecrotch"))
+    # )
+    print(stats.get_botlane_stats(Summoner(name="who what")))
 
 if __name__ == "__main__":
     main()

--- a/queries.py
+++ b/queries.py
@@ -118,6 +118,12 @@ Get a list of up to 100 matches according to parameters:
 '''
 @request_wrapper
 def get_matches(summoner, champion=None, queue=None, season=None, beginTime=None, endTime=None, beginIndex=0, endIndex=100):
+    if endIndex - beginIndex > 100:
+        print("Cannot fetch more than 100 matches")
+        print("Begin:", beginIndex)
+        print("End:", endIndex)
+        exit(1)
+
     route = 'match/v4/matchlists/by-account/%s' % summoner.acc_id
     response = requests.get(API_URL + route, params={
         'api_key': API_KEY,

--- a/stats.py
+++ b/stats.py
@@ -223,11 +223,18 @@ def get_botlane_stats(summoner):
 Get duo win-rate
 '''
 def get_duo_wr(summoner1, summoner2):
-    s1_matches = queries.get_all_matches(summoner1, debug=True)
-
+    s1_matches = queries.get_matches(summoner1, debug=True)["matches"]
+    won = 0
+    lost = 0
     for match_meta in s1_matches:
-        match = get_match(match_meta["id"])
+        match = queries.get_match(match_meta["gameId"])
         summoner_names = util.summoner_names_in_match(match)
-        print(summoner_names)
-        exit(1)
+        if summoner2.name in summoner_names:
+            if(util.summoner_won_match(summoner1, match)):
+                won += 1
+            else:
+                lost += 1
+    
+    return (won, lost)
+
 

--- a/stats.py
+++ b/stats.py
@@ -223,18 +223,16 @@ def get_botlane_stats(summoner):
 Get duo win-rate
 '''
 def get_duo_wr(summoner1, summoner2):
-    s1_matches = queries.get_matches(summoner1, debug=True)["matches"]
+    s1_matches = queries.get_all_matches(summoner1, debug=True)["matches"]
     won = 0
     lost = 0
     for match_meta in s1_matches:
         match = queries.get_match(match_meta["gameId"])
-        summoner_names = util.summoner_names_in_match(match)
-        if summoner2.name in summoner_names:
+        summoner_ids = util.summoner_ids_in_match(match)
+        if summoner2.sum_id in summoner_ids:
             if(util.summoner_won_match(summoner1, match)):
                 won += 1
             else:
                 lost += 1
     
     return (won, lost)
-
-

--- a/stats.py
+++ b/stats.py
@@ -10,18 +10,7 @@ from pprint import pprint
 Get list of all matches on of a summoner on a specific champ. Wrapper around get_matches
 '''
 def get_matches_by_champ(summoner, champ_id):
-    matches = []
-    start = 0
-    end = 100
-    while True:
-        m = queries.get_matches(summoner, champion=champ_id, beginIndex=start, endIndex=end)
-        if len(m) == 0:
-            return matches
-        else:
-            matches.extend(m)
-            start += 100
-            end += 100
-
+    return queries.get_all_matches(summoner, champion=champ_id)
 
 '''
 Print out aggregate stats for summoner on a particular champion
@@ -229,3 +218,16 @@ def get_botlane_stats(summoner):
             invalid_bots.append(m['gameId'])
 
     return (summoners_bot_won, summoners_bot_lost)
+
+'''
+Get duo win-rate
+'''
+def get_duo_wr(summoner1, summoner2):
+    s1_matches = queries.get_all_matches(summoner1, debug=True)
+
+    for match_meta in s1_matches:
+        match = get_match(match_meta["id"])
+        summoner_names = util.summoner_names_in_match(match)
+        print(summoner_names)
+        exit(1)
+

--- a/stats.py
+++ b/stats.py
@@ -161,7 +161,7 @@ Criteria:
 '''
 def get_botlane_stats(summoner):
     # out of the last 20 games, show how many bots won/lost
-    last_20_matches = queries.get_matches(summoner, endIndex=20)
+    last_20_matches = queries.get_matches(summoner, endIndex=20)['matches']
 
     summoners_bot_won = 0
     summoners_bot_lost = 0
@@ -177,10 +177,10 @@ def get_botlane_stats(summoner):
             champ = util.get_champ_name(player['championId'])
             participant = util.participant_by_id(player['participantId'], match)
             if participant['player']['summonerId'] == summoner.sum_id:
-                summoner_is_blue_side = util.is_blue_side(player)
+                summoner_is_blue_side = util.is_summoner_on_blue_side_in_match(summoner, match)
 
-            if util.is_bot(player):
-                if util.is_blue_side(player):
+            if util.is_player_bot(player):
+                if util.is_player_blue_on_blue_in_match(player, match):
                     blue_bot.append((player, participant))
                 else:
                     red_bot.append((player, participant))

--- a/util.py
+++ b/util.py
@@ -14,8 +14,14 @@ def write_file(path, text):
     with open(path, "a") as f:
         f.write(text)
 
-
 CHAMPS = json.loads(read_file('champions.json'))['data'] # Locally stored champs
+
+'''
+Error out when summoner isn't in a given match
+'''
+def summoner_not_in_match(summoner, match):
+    print(f"Summoner {summoner.name} does not exist in the match {match['gameId']}")
+    exit(1)
 
 '''
 Get unique Champion ID attached to a champion. Included in this project is a json
@@ -48,16 +54,14 @@ def is_bot(player):
 '''
 Returns True if player is on blue side
 '''
-def is_blue_side(player):
-    return player['teamId'] == 100
-
-
-'''
-Returns True if player is on red side
-'''
-def is_red_side(player):
-    return player['teamId'] == 200
-
+def is_summoner_on_blue_side_in_match(summoner, match):
+    print(match)
+    exit(1)
+    for p in match['participantIdentities']:
+        if p['player']['summonerId'] == summoner.sum_id:
+            return p['player']['teamId'] == 100
+    
+    summoner_not_in_match(summoner, match)
 
 
 '''
@@ -69,7 +73,20 @@ def participant_id_for_summoner_in_match(summoner, match):
     for p in participants:
         if p['player']['summonerId'] == summoner.sum_id:
             return p['participantId']
-    return None
+    
+    summoner_not_in_match(summoner, match)
+
+
+'''
+Returns True if summoner won
+'''
+def summoner_won_match(summoner, match):
+    p_id = participant_id_for_summoner_in_match(summoner, match)
+    for p in match['participants']:
+        if p['participantId'] == p_id:
+            return p['stats']['win']
+
+    summoner_not_in_match(summoner, match)
 
 
 '''
@@ -78,17 +95,19 @@ Get single game data (Kills, Deaths, Assists) for summoner
 def match_stats_for_sum(summoner, match):
     p_id = participant_id_for_summoner_in_match(summoner, match)
 
-    result = {}
     players = match['participants']
     for p in players:
         if p['participantId'] == p_id:
             stats = p['stats']
-            result['kills'] = stats['kills']
-            result['deaths'] = stats['deaths']
-            result['assists'] = stats['assists']
-            result['vision'] = stats['visionScore']
-            result['cs'] = stats['totalMinionsKilled']
-    return result
+            return {
+                'kills': stats['kills'],
+                'deaths': stats['deaths'],
+                'assists': stats['assists'],
+                'vision': stats['visionScore'],
+                'cs': stats['totalMinionsKilled']
+            }
+    
+    summoner_not_in_match(summoner, match)
 
 
 '''

--- a/util.py
+++ b/util.py
@@ -125,6 +125,14 @@ def vision_score(player_participants, match):
         vision_score += stats['vision']
     return vision_score
 
+'''
+Get all summoner names in a game
+'''
+def summoner_names_in_match(match):
+    names = []
+    for participant in match["participantIdentities"]:
+        names.append(participant["player"]["summonerName"])
+    return names
 
 '''
 Get participant by ID
@@ -135,4 +143,3 @@ def participant_by_id(p_id, match):
         if p['participantId'] == p_id:
             return p
     return None
-

--- a/util.py
+++ b/util.py
@@ -47,18 +47,26 @@ def get_champ_name(champ_id):
 '''
 Returns True if player is in the bottom lane
 '''
-def is_bot(player):
+def is_player_bot(player):
     return (player['timeline']['lane'] == 'BOTTOM')
 
 
 '''
+Returns True if player is in the bottom lane
+'''
+def is_player_blue_on_blue_in_match(player, match):
+    for p in match['participantIdentities']:
+        if player['summonerId'] == summoner.sum_id:
+            return player['teamId'] == 100
+
+    raise Exception("Player not in match")
+'''
 Returns True if player is on blue side
 '''
 def is_summoner_on_blue_side_in_match(summoner, match):
-    print(match)
-    exit(1)
     for p in match['participantIdentities']:
         if p['player']['summonerId'] == summoner.sum_id:
+            pprint(match['participants'])
             return p['player']['teamId'] == 100
     
     summoner_not_in_match(summoner, match)

--- a/util.py
+++ b/util.py
@@ -154,6 +154,15 @@ def summoner_names_in_match(match):
     return names
 
 '''
+Get all summoner_ids in a game
+'''
+def summoner_ids_in_match(match):
+    names = []
+    for participant in match["participantIdentities"]:
+        names.append(participant["player"]["summonerId"])
+    return names
+
+'''
 Get participant by ID
 '''
 def participant_by_id(p_id, match):


### PR DESCRIPTION
Also:
- Rework the request wrapper to get rid of `check_response`
- Add automatic retry on server-side failure
- Add link to api key regen page when user isn't authenticated
- Add routine to get all matches for a summoner with `kwargs`
- Standardize `util` as non-networked helpers, and add a bunch of helpers