### PR TITLE
Fix ci test script

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -21,9 +21,19 @@ help()
 
 }
 
+unameOut="$(uname -s)"
+case "${unameOut}" in
+    Linux*)     py_cmd=python3;;
+    Darwin*)    py_cmd=python3;;
+    CYGWIN*)    py_cmd=python;;
+    MINGW*)     py_cmd=python;;
+    *)          py_cmd=python;;
+esac
+echo ${py_cmd}
+
 if [[ $# -eq 0 ]]
 then
-  python3 -m unittest discover .
+  ${py_cmd} -m unittest discover .
 elif [[ "$1" = "-h" || "$1" = "--help" || "$1" = "help" ]]
 then
   help
@@ -31,7 +41,7 @@ else
   for test_case in "$@"
   do
     echo "Running $test_case..."
-    python3 -m unittest "$test_case"
+    ${py_cmd} -m unittest "$test_case"
     echo
     echo
   done

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -81,7 +81,7 @@ class GroupParticipantsScoresTestCase(unittest.TestCase):
         ]
 
     def test_kda_score(self):
-        self.assertEqual(util.kda_score(self.test_participants), 3)
+        self.assertEqual(util.kda_score(self.test_participants), (16, 8, 8))
     
     def test_cs_score(self):
         self.assertEqual(util.cs_score(self.test_participants), 400)


### PR DESCRIPTION
Quick fix to the CI test script which wouldn't run correctly on platforms that assume `python3` exists as a binary, also fix the broken unittest